### PR TITLE
Added cross-platform thread-local exception handling to N-API wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ clean:
 	rm -f pinggy.dll
 	rm -f pinggy.dylib
 	rm -f ../.prebuild-step-done
+	rm -f .prebuild-step-done
 	node-gyp clean
 
 install:

--- a/demo.ts
+++ b/demo.ts
@@ -3,7 +3,7 @@ import pinggy, { PinggyOptions } from "./src/index";
 (async () => {
   const options: PinggyOptions = {
     forwardTo: "localhost:3000",
-    type: "http" // defaults to http if not provided 
+    type: "http", // defaults to http if not provided
   };
   const addresses = await pinggy.startTunnel(options);
 
@@ -11,11 +11,11 @@ import pinggy, { PinggyOptions } from "./src/index";
   console.log("Server address:", pinggy.getServerAddress());
 
   pinggy.startWebDebugging(8080);
-  
-  console.log("about to stop tunnel")
+
+  console.log("about to stop tunnel");
   setTimeout(async () => {
     try {
-      console.log("Stopping tunnel...")
+      console.log("Stopping tunnel...");
       await pinggy.close();
       console.log("Tunnel cleanly closed.");
     } catch (err) {

--- a/install.js
+++ b/install.js
@@ -149,7 +149,7 @@ function extractArchive(archivePath, outDir, innerLibName, destLibPath) {
     fs.unlinkSync(destArchivePath);
     console.log(`[Pinggy Prebuild] Successfully extracted ${innerLibName}`);
 
-    fs.writeFileSync(path.join(__dirname, "..", ".prebuild-step-done"), "done");
+    fs.writeFileSync(path.join(__dirname, ".prebuild-step-done"), "done");
   } catch (err) {
     console.error(`Download or extraction failed: ${err.message}`);
     process.exit(1);


### PR DESCRIPTION
- **Dynamic TLS Buffers:** Platform-specific thread-local storage is used (`TlsAlloc` for Windows, `pthread_key` for POSIX) with dynamic memory allocation for exception messages.
- **Pinggy Integration:** Registered `pinggy_set_exception_callback` to store exceptions in TLS.
- **Automatic Cleanup:** Registered `napi_add_env_cleanup_hook` to free TLS slots on Windows during environment shutdown.

Closes #21 