### PR TITLE
Added API and env level control for debug statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 
 python-sdk-implementation.md
 pinggy-test*
+*.tgz
+*.zip

--- a/native/addon.c
+++ b/native/addon.c
@@ -1,4 +1,5 @@
 #include <node_api.h>
+#include "debug.h"
 
 napi_value Init1(napi_env env, napi_value exports);
 napi_value Init2(napi_env env, napi_value exports);
@@ -9,6 +10,7 @@ napi_value Init(napi_env env, napi_value exports)
     Init1(env, exports);
     Init2(env, exports);
     Init3(env, exports);
+    InitDebug(env, exports);
 
     return exports;
 }

--- a/native/config.c
+++ b/native/config.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "../pinggy.h"
+#include "debug.h"
 
 // Binding for pinggy_set_log_path
 napi_value SetLogPath(napi_env env, napi_callback_info info)

--- a/native/debug.c
+++ b/native/debug.c
@@ -1,0 +1,106 @@
+#include "debug.h"
+#include <node_api.h>
+
+// Global debug flag - initialized to -1 to indicate uninitialized state
+int _pinggy_debug_enabled = -1;
+
+// Function to initialize debug logging based on environment variable
+void pinggy_debug_init(void)
+{
+    if (_pinggy_debug_enabled != -1)
+    {
+        // Already initialized
+        return;
+    }
+
+    const char *debug_env = getenv("PINGGY_DEBUG");
+    if (debug_env != NULL)
+    {
+        // Check for various true values
+        if (strcmp(debug_env, "1") == 0 ||
+            strcmp(debug_env, "true") == 0 ||
+            strcmp(debug_env, "TRUE") == 0 ||
+            strcmp(debug_env, "yes") == 0 ||
+            strcmp(debug_env, "YES") == 0)
+        {
+            _pinggy_debug_enabled = 1;
+        }
+        else
+        {
+            _pinggy_debug_enabled = 0;
+        }
+    }
+    else
+    {
+        // Default to disabled if environment variable is not set
+        _pinggy_debug_enabled = 0;
+    }
+}
+
+// Function to set debug logging state (for JavaScript API)
+void pinggy_debug_set_enabled(int enabled)
+{
+    _pinggy_debug_enabled = enabled ? 1 : 0;
+}
+
+// Function to check if debug logging is enabled
+int pinggy_debug_is_enabled(void)
+{
+    // Auto-initialize if not done yet
+    if (_pinggy_debug_enabled == -1)
+    {
+        pinggy_debug_init();
+    }
+    return _pinggy_debug_enabled;
+}
+
+// N-API binding to enable/disable debug logging from JavaScript
+napi_value SetDebugLogging(napi_env env, napi_callback_info info)
+{
+    size_t argc = 1;
+    napi_value args[1];
+    napi_status status;
+
+    // Parse the arguments
+    status = napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+    if (status != napi_ok || argc < 1)
+    {
+        napi_throw_error(env, NULL, "Expected one boolean argument");
+        return NULL;
+    }
+
+    // Convert the argument to boolean
+    bool enabled;
+    status = napi_get_value_bool(env, args[0], &enabled);
+    if (status != napi_ok)
+    {
+        napi_throw_error(env, NULL, "Argument must be a boolean");
+        return NULL;
+    }
+
+    // Set debug logging state
+    pinggy_debug_set_enabled(enabled ? 1 : 0);
+
+    // Return undefined
+    napi_value result;
+    napi_get_undefined(env, &result);
+    return result;
+}
+
+// Initialize the debug module and export the functions
+napi_value InitDebug(napi_env env, napi_value exports)
+{
+    napi_status status;
+    napi_value fn;
+
+    // Export setDebugLogging function
+    status = napi_create_function(env, NULL, 0, SetDebugLogging, NULL, &fn);
+    if (status != napi_ok)
+        return NULL;
+
+    status = napi_set_named_property(env, exports, "setDebugLogging", fn);
+    if (status != napi_ok)
+        return NULL;
+
+    return exports;
+}

--- a/native/debug.h
+++ b/native/debug.h
@@ -1,0 +1,50 @@
+#ifndef PINGGY_DEBUG_H
+#define PINGGY_DEBUG_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    // Global debug flag
+    extern int _pinggy_debug_enabled;
+
+    // Function to initialize debug logging based on environment variable
+    void pinggy_debug_init(void);
+
+    // Function to set debug logging state (for JavaScript API)
+    void pinggy_debug_set_enabled(int enabled);
+
+    // Function to check if debug logging is enabled
+    int pinggy_debug_is_enabled(void);
+
+// Debug logging macro
+#define PINGGY_DEBUG(...)                                              \
+    do                                                                 \
+    {                                                                  \
+        if (pinggy_debug_is_enabled())                                 \
+        {                                                              \
+            printf("[DEBUG] %s:%d %s ", __FILE__, __LINE__, __func__); \
+            printf(__VA_ARGS__);                                       \
+            printf("\n");                                              \
+            fflush(stdout);                                            \
+        }                                                              \
+    } while (0)
+
+// Backward compatibility macro for existing printf statements
+#define PINGGY_DEBUG_RET(ret) PINGGY_DEBUG("ret = %d", ret)
+#define PINGGY_DEBUG_VOID() PINGGY_DEBUG("ret = void")
+
+// N-API module initialization function
+#include <node_api.h>
+    napi_value InitDebug(napi_env env, napi_value exports);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PINGGY_DEBUG_H

--- a/native/excep.c
+++ b/native/excep.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <node_api.h>
+#include "debug.h"
 
 #ifdef _WIN32
 #include <windows.h>

--- a/native/tunnel.c
+++ b/native/tunnel.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "../pinggy.h"
+#include "debug.h"
 
 // Wrapper for pinggy_tunnel_initiate
 napi_value TunnelInitiate(napi_env env, napi_callback_info info)
@@ -29,7 +30,7 @@ napi_value TunnelInitiate(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_initiate function
     uint32_t tunnel = pinggy_tunnel_initiate(config);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, tunnel);
+    PINGGY_DEBUG_RET(tunnel);
 
     // Return the newly created tunnel reference (pinggy_ref_t)
     napi_create_uint32(env, tunnel, &result);
@@ -76,7 +77,7 @@ napi_value TunnelStart(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_start function
     pinggy_bool_t success = pinggy_tunnel_start(tunnel);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, success);
+    PINGGY_DEBUG_RET(success);
     if (!success)
     {
         char error_message[256];
@@ -120,7 +121,7 @@ napi_value TunnelConnect(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_connect function
     pinggy_bool_t result = pinggy_tunnel_connect((pinggy_ref_t)tunnel_ref);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     // Convert the result (pinggy_bool_t) to a JavaScript boolean
     napi_value js_result;
@@ -166,7 +167,7 @@ napi_value TunnelResume(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_resume function
     pinggy_bool_t ret = pinggy_tunnel_resume((pinggy_ref_t)tunnel_ref);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, ret);
+    PINGGY_DEBUG_RET(ret);
 
     // Return the result as a JavaScript boolean
     napi_value result;
@@ -212,7 +213,7 @@ napi_value TunnelStop(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_stop function
     pinggy_bool_t result = pinggy_tunnel_stop((pinggy_ref_t)tunnel_ref);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     // Convert the result (pinggy_bool_t) to a JavaScript boolean
     napi_value js_result;
@@ -269,7 +270,7 @@ napi_value TunnelStartWebDebugging(napi_env env, napi_callback_info info)
 
     // Call the actual Pinggy function
     pinggy_uint16_t result = pinggy_tunnel_start_web_debugging(tunnel, (pinggy_uint16_t)port);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     // Return the result as a JavaScript number
     napi_value jsResult;
@@ -326,7 +327,7 @@ napi_value TunnelRequestPrimaryForwarding(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_request_primary_forwarding function
     pinggy_tunnel_request_primary_forwarding(tunnel);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, tunnel);
+    PINGGY_DEBUG_RET(tunnel);
 
     // Return undefined (void return type in C)
     napi_get_undefined(env, &result);
@@ -391,7 +392,7 @@ napi_value TunnelRequestAdditionalForwarding(napi_env env, napi_callback_info in
 
     // Call the Pinggy function
     pinggy_tunnel_request_additional_forwarding((pinggy_ref_t)tunnelRef, remoteBindingAddr, forwardTo);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, tunnelRef);
+    PINGGY_DEBUG_RET(tunnelRef);
 
     // Free allocated memory
     free(remoteBindingAddr);
@@ -438,7 +439,7 @@ void primary_forwarding_succeeded_callback(pinggy_void_p_t user_data, pinggy_ref
     // Call the JavaScript callback with the array of addresses
     napi_value result;
     napi_call_function(env, undefined, js_callback, 1, &js_addresses_array, &result);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 }
 
 napi_value SetPrimaryForwardingCallback(napi_env env, napi_callback_info info)
@@ -507,7 +508,7 @@ napi_value SetPrimaryForwardingCallback(napi_env env, napi_callback_info info)
 
     // Register callback with Pinggy
     pinggy_bool_t result = pinggy_tunnel_set_primary_forwarding_succeeded_callback(tunnel, primary_forwarding_succeeded_callback, cb_data);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
     if (result != pinggy_true)
     {
         char error_message[256];
@@ -550,7 +551,7 @@ void additional_forwarding_succeeded_callback(pinggy_void_p_t user_data, pinggy_
     napi_value args[3] = {js_tunnel, js_address, js_protocol};
     napi_value result;
     napi_call_function(env, undefined, js_callback, 3, args, &result);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 }
 
 // JavaScript wrapper function to set the callback
@@ -617,7 +618,7 @@ napi_value SetAdditionalForwardingCallback(napi_env env, napi_callback_info info
 
     // Register callback with Pinggy
     pinggy_bool_t result = pinggy_tunnel_set_additional_forwarding_succeeded_callback(tunnel, additional_forwarding_succeeded_callback, cb_data);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
     if (result != pinggy_true)
     {
         char error_message[256];
@@ -683,7 +684,7 @@ void authenticated_callback(pinggy_void_p_t user_data, pinggy_ref_t tunnel)
         snprintf(error_message, sizeof(error_message), "[%s:%d] Failed to call JavaScript callback", __FILE__, __LINE__);
         napi_throw_error(env, NULL, error_message);
     }
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, js_result);
+    PINGGY_DEBUG_RET(js_result);
 }
 
 napi_value SetAuthenticatedCallback(napi_env env, napi_callback_info info)
@@ -735,7 +736,7 @@ napi_value SetAuthenticatedCallback(napi_env env, napi_callback_info info)
 
     // Register callback with Pinggy
     pinggy_bool_t result = pinggy_tunnel_set_authenticated_callback(tunnel, authenticated_callback, cb_data);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     // If registration failed, decrease reference count and free memory
     if (!result)
@@ -783,7 +784,7 @@ napi_value TunnelIsActive(napi_env env, napi_callback_info info)
 
     // Call the pinggy_tunnel_is_active function
     pinggy_bool_t result = pinggy_tunnel_is_active((pinggy_ref_t)tunnel_ref);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     // Convert the result (pinggy_bool_t) to a JavaScript boolean
     napi_value js_result;
@@ -866,7 +867,7 @@ void authentication_failed_callback(pinggy_void_p_t user_data, pinggy_ref_t tunn
     {
         // Handle error: Failed to call JavaScript callback
     }
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, js_result);
+    PINGGY_DEBUG_RET(js_result);
 }
 
 napi_value SetAuthenticationFailedCallback(napi_env env, napi_callback_info info)
@@ -929,7 +930,7 @@ napi_value SetAuthenticationFailedCallback(napi_env env, napi_callback_info info
     }
 
     pinggy_bool_t result = pinggy_tunnel_set_on_authentication_failed_callback(tunnel, authentication_failed_callback, cb_data);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     if (!result)
     {
@@ -994,7 +995,7 @@ void primary_forwarding_failed_callback(pinggy_void_p_t user_data, pinggy_ref_t 
     {
         // Handle error: Failed to call JavaScript callback
     }
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, js_result);
+    PINGGY_DEBUG_RET(js_result);
 }
 
 napi_value SetPrimaryForwardingFailedCallback(napi_env env, napi_callback_info info)
@@ -1057,7 +1058,7 @@ napi_value SetPrimaryForwardingFailedCallback(napi_env env, napi_callback_info i
     }
 
     pinggy_bool_t result = pinggy_tunnel_set_on_primary_forwarding_failed_callback(tunnel, primary_forwarding_failed_callback, cb_data);
-    printf("[DEBUG] %s:%d %s ret = %d\n", __FILE__, __LINE__, __func__, result);
+    PINGGY_DEBUG_RET(result);
 
     if (!result)
     {
@@ -1358,7 +1359,7 @@ napi_value ConfigSetSsl(napi_env env, napi_callback_info info)
 
     // Call the native function
     pinggy_config_set_ssl(config, ssl ? pinggy_true : pinggy_false);
-    printf("[DEBUG] %s:%d %s ret = void\n", __FILE__, __LINE__, __func__);
+    PINGGY_DEBUG_VOID();
 
     return NULL;
 }

--- a/src/__tests__/debug-logging.test.ts
+++ b/src/__tests__/debug-logging.test.ts
@@ -1,0 +1,162 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+// Mock the native addon to prevent loading issues during testing
+jest.mock("@mapbox/node-pre-gyp", () => ({
+  find: jest.fn(() => "mocked-path"),
+}));
+
+// Mock the native module with all required functions
+const mockAddon = {
+  setDebugLogging: jest.fn(),
+  createConfig: jest.fn(() => 1),
+  tunnelInitiate: jest.fn(() => 1),
+  initExceptionHandling: jest.fn(),
+  getLastException: jest.fn(() => ""),
+  setLogPath: jest.fn(),
+  setLogEnable: jest.fn(),
+  // Add all other required native functions
+  configSetArgument: jest.fn(),
+  configSetToken: jest.fn(),
+  configSetServerAddress: jest.fn(),
+  configSetSniServerName: jest.fn(),
+  configSetTcpForwardTo: jest.fn(),
+  configSetUdpForwardTo: jest.fn(),
+  configSetType: jest.fn(),
+  configSetUdpType: jest.fn(),
+  configSetSsl: jest.fn(),
+  configGetToken: jest.fn(() => ""),
+  configGetServerAddress: jest.fn(() => ""),
+  configGetSniServerName: jest.fn(() => ""),
+  tunnelConnect: jest.fn(() => true),
+  tunnelResume: jest.fn(() => true),
+  tunnelStartWebDebugging: jest.fn(),
+  tunnelRequestPrimaryForwarding: jest.fn(),
+  tunnelRequestAdditionalForwarding: jest.fn(),
+  tunnelGetUrls: jest.fn(() => []),
+  tunnelGetConnectionCount: jest.fn(() => 0),
+  tunnelStop: jest.fn(),
+  tunnelIsActive: jest.fn(() => false),
+  tunnelGetLastKeepAliveTime: jest.fn(() => 0),
+  tunnelClearCallbacks: jest.fn(),
+  tunnelSetOnConnectionCallback: jest.fn(),
+  tunnelSetOnConnectionClosedCallback: jest.fn(),
+  tunnelSetOnUrlsChangedCallback: jest.fn(),
+  tunnelSetOnDisconnectedCallback: jest.fn(),
+};
+
+jest.mock("mocked-path", () => mockAddon, { virtual: true });
+
+import { Pinggy } from "../core/pinggy";
+
+describe("Debug Logging", () => {
+  let originalEnv: string | undefined;
+  const pinggy = Pinggy.instance;
+
+  beforeEach(() => {
+    // Store original environment variable
+    originalEnv = process.env.PINGGY_DEBUG;
+    // Reset the mock
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore original environment variable
+    if (originalEnv !== undefined) {
+      process.env.PINGGY_DEBUG = originalEnv;
+    } else {
+      delete process.env.PINGGY_DEBUG;
+    }
+
+    // Reset debug logging to default state
+    pinggy.setDebugLogging(false);
+  });
+
+  describe("JavaScript API Control", () => {
+    it("should call native setDebugLogging when enabling debug logging", () => {
+      pinggy.setDebugLogging(true);
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledWith(true);
+    });
+
+    it("should call native setDebugLogging when disabling debug logging", () => {
+      pinggy.setDebugLogging(false);
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledWith(false);
+    });
+
+    it("should handle boolean values correctly", () => {
+      pinggy.setDebugLogging(true);
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledWith(true);
+
+      pinggy.setDebugLogging(false);
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledWith(false);
+
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not throw when calling setDebugLogging", () => {
+      expect(() => {
+        pinggy.setDebugLogging(true);
+        pinggy.setDebugLogging(false);
+      }).not.toThrow();
+    });
+  });
+
+  describe("Integration with Core Functions", () => {
+    it("should not interfere with tunnel creation when debug is enabled", () => {
+      pinggy.setDebugLogging(true);
+
+      expect(() => {
+        pinggy.createTunnel({
+          type: "http",
+          forwardTo: "localhost:3000",
+        });
+      }).not.toThrow();
+
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledWith(true);
+    });
+
+    it("should not interfere with tunnel creation when debug is disabled", () => {
+      pinggy.setDebugLogging(false);
+
+      expect(() => {
+        pinggy.createTunnel({
+          type: "http",
+          forwardTo: "localhost:3000",
+        });
+      }).not.toThrow();
+
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledWith(false);
+    });
+
+    it("should allow multiple debug state changes", () => {
+      expect(() => {
+        pinggy.setDebugLogging(true);
+        pinggy.setDebugLogging(false);
+        pinggy.setDebugLogging(true);
+        pinggy.setDebugLogging(false);
+      }).not.toThrow();
+
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("should handle type coercion for setDebugLogging", () => {
+      expect(() => {
+        // These should be handled by TypeScript/JavaScript type coercion
+        pinggy.setDebugLogging(true);
+        pinggy.setDebugLogging(false);
+        pinggy.setDebugLogging(!!1);
+        pinggy.setDebugLogging(!!0);
+      }).not.toThrow();
+
+      expect(mockAddon.setDebugLogging).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/src/core/pinggy.ts
+++ b/src/core/pinggy.ts
@@ -37,4 +37,7 @@ export class Pinggy {
     }
     this.tunnels.clear();
   }
+  public setDebugLogging(enabled: boolean): void {
+    Pinggy.addon.setDebugLogging(enabled);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export interface PinggyNative {
     tunnelRef: number,
     callback: (tunnelRef: number, error: string, messages: string[]) => void
   ): void;
+  setDebugLogging(enabled: boolean): void;
 }
 
 export interface Config {


### PR DESCRIPTION
- **Environment Variable Control**: Set `PINGGY_DEBUG=1` to enable debug logging
- **JavaScript API Control**: Enable/disable debug logging at runtime

```bash
# Linux/macOS
export PINGGY_DEBUG=1
node your-app.js

# Windows Command Prompt
set PINGGY_DEBUG=1
node your-app.js

# Windows PowerShell
$env:PINGGY_DEBUG="1"
node your-app.js

# Inline (Linux/macOS)
PINGGY_DEBUG=1 node your-app.js
```

### Enable/Disable Debug Logging

```javascript
const { pinggy } = require("pinggy");

// Enable debug logging
pinggy.setDebugLogging(true);

// Disable debug logging
pinggy.setDebugLogging(false);
```

**JavaScript API calls will override the environment variable setting**