### PR TITLE
Added support for forwarding express apps

### DIFF
--- a/examples/JS/EXAMPLES_EXPRESS_LISTEN.md
+++ b/examples/JS/EXAMPLES_EXPRESS_LISTEN.md
@@ -1,0 +1,65 @@
+# Example: Using `pinggy.listen` with Express
+
+This example demonstrates how to use the new `pinggy.listen` feature to start an Express app and automatically tunnel it with Pinggy in a single step.
+
+## Prerequisites
+
+- Install dependencies:
+  ```sh
+  npm install express pinggy
+  ```
+
+## Usage (async/await)
+
+```js
+const express = require("express");
+const { listen } = require("pinggy");
+
+const app = express();
+app.get("/", (req, res) => res.send("Hello from Express over Pinggy!"));
+
+(async () => {
+  // Start the Express app and tunnel it in one step
+  const server = await listen(app);
+
+  // Access the tunnel instance via server.tunnel
+  console.log("Tunnel public URL:", server.tunnel.urls()[0]);
+  console.log("Local server port:", server.address().port);
+
+  // Clean up when done
+  // server.close();
+  // server.tunnel.stop();
+})();
+```
+
+## Usage (.then syntax)
+
+```js
+const express = require("express");
+const { listen } = require("pinggy");
+
+const app = express();
+app.get("/", (req, res) => res.send("Hello from Express over Pinggy!"));
+
+listen(app).then((server) => {
+  console.log("Tunnel public URL:", server.tunnel.urls()[0]);
+  console.log("Local server port:", server.address().port);
+
+  // Clean up when done
+  // server.close();
+  // server.tunnel.stop();
+});
+```
+
+## What this does
+
+- Starts your Express app on a random available port.
+- Creates a Pinggy tunnel to that port.
+- Attaches the tunnel instance to the server as `server.tunnel`.
+- Prints the public tunnel URL and the local port.
+
+## Notes
+
+- You can use all Express features as usual.
+- You can access all Pinggy tunnel methods via `server.tunnel`.
+- Remember to stop the server and tunnel when done to free resources.

--- a/examples/JS/express-listen-example.js
+++ b/examples/JS/express-listen-example.js
@@ -1,0 +1,17 @@
+// See EXAMPLES_EXPRESS_LISTEN.md for full documentation and more usage notes
+const express = require("express");
+const { listen } = require("pinggy");
+
+const app = express();
+app.get("/", (req, res) => res.send("Hello from Express over Pinggy!"));
+
+listen(app, {
+  /* you can add PinggyOptions here, e.g. token: "..." */
+}).then((server) => {
+  console.log("Tunnel public URL:", server.tunnel.urls()[0]);
+  console.log("Local server port:", server.address().port);
+
+  // Clean up when done
+  // server.close();
+  // server.tunnel.stop();
+});

--- a/src/__tests__/express-api.test.ts
+++ b/src/__tests__/express-api.test.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import type { Express } from "express";
+import { listen } from "../utils/listen";
+import supertest from "supertest";
+import type { SuperTest, Test } from "supertest";
+
+describe("pinggy.listen with Express app", () => {
+  let server: any;
+
+  afterAll(async () => {
+    if (server) {
+      server.close();
+      if (server.tunnel) await server.tunnel.stop();
+    }
+  });
+
+  it("should start an Express app, tunnel it, and attach tunnel to server", async () => {
+    const app = express();
+    app.get("/", (req: any, res: any) => res.send("Hello from Express!"));
+
+    server = await listen(app);
+    expect(server).toBeDefined();
+    expect(server.tunnel).toBeDefined();
+    expect(typeof server.tunnel.urls).toBe("function");
+    expect(server.address().port).toBeGreaterThan(0);
+
+    // Test local server
+    const localRes = await supertest(
+      `http://localhost:${server.address().port}`
+    ).get("/");
+    expect(localRes.status).toBe(200);
+    expect(localRes.text).toBe("Hello from Express!");
+
+    // Optionally, print tunnel URL (public test may not be feasible in CI)
+    const urls = server.tunnel.urls();
+    expect(Array.isArray(urls)).toBe(true);
+    expect(urls.length).toBeGreaterThan(0);
+    console.log("Tunnel public URL:", urls[0]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ import { TunnelInstance } from "./core/tunnel-instance";
 const pinggy = Pinggy.instance;
 export { pinggy, TunnelInstance };
 export type { PinggyOptions };
+export { listen } from "./utils/listen";

--- a/src/utils/listen.ts
+++ b/src/utils/listen.ts
@@ -1,0 +1,88 @@
+import { pinggy, PinggyOptions, TunnelInstance } from "../index";
+import * as http from "http";
+
+/**
+ * listen overloads:
+ * - listen(app: Express, options?: PinggyOptions): Promise<http.Server & { tunnel: TunnelInstance }>
+ * - listen(server: http.Server, options?: PinggyOptions): Promise<http.Server & { tunnel: TunnelInstance }>
+ */
+export async function listen(
+  app: http.Server | any,
+  options?: PinggyOptions
+): Promise<http.Server & { tunnel: TunnelInstance }> {
+  let server: http.Server | undefined = undefined;
+  let startedHere = false;
+
+  // Helper: is http.Server
+  function isHttpServer(obj: any): obj is http.Server {
+    return (
+      obj &&
+      typeof obj === "object" &&
+      typeof obj.listen === "function" &&
+      typeof obj.address === "function"
+    );
+  }
+
+  // Helper: is Express app (function with .listen)
+  function isExpressApp(obj: any): boolean {
+    return typeof obj === "function" && typeof obj.listen === "function";
+  }
+
+  if (!isHttpServer(app) && !isExpressApp(app)) {
+    throw new Error(
+      "listen() expects an Express app or http.Server as the first argument."
+    );
+  }
+
+  // If Express app, start it
+  if (isExpressApp(app)) {
+    server = app.listen(0); // random port
+    startedHere = true;
+    await new Promise((resolve, reject) => {
+      server!.once("listening", resolve);
+      server!.once("error", reject);
+    });
+  } else if (isHttpServer(app)) {
+    server = app;
+    // If not listening, start it
+    if (!server.address()) {
+      server.listen(0);
+      startedHere = true;
+      await new Promise((resolve, reject) => {
+        server!.once("listening", resolve);
+        server!.once("error", reject);
+      });
+    }
+  }
+
+  if (!server) {
+    throw new Error("Server was not initialized.");
+  }
+
+  // Get the port
+  const addr = server.address();
+  if (!addr || typeof addr !== "object" || !addr.port) {
+    if (startedHere) server.close();
+    throw new Error("Could not determine server port after listen().");
+  }
+  const port = addr.port;
+
+  // Merge options with detected port
+  const tunnelOptions: PinggyOptions = {
+    ...options,
+    forwardTo: `localhost:${port}`,
+  };
+
+  // Start the tunnel
+  let tunnel: TunnelInstance;
+  try {
+    tunnel = await pinggy.forward(tunnelOptions);
+  } catch (err) {
+    if (startedHere) server.close();
+    throw err;
+  }
+
+  // Attach tunnel to server
+  (server as any).tunnel = tunnel;
+  return server as http.Server & { tunnel: TunnelInstance };
+}


### PR DESCRIPTION
Closes #39 

Previousy followed two step approach of first creating express server, then using pinggy to forward, simplified with a one step solution to handle both

**Note:** it finds a random port and forwardTo config option won't work in this case

```js
listen(app, { token: "X8bShZBD16S" }).then((server) => {
  console.log("Tunnel URL:", server.tunnel.urls()[0]);
  console.log("Local server port:", server.address().port);
});
```